### PR TITLE
Updates swift plugin to use PNG instead of JPEG

### DIFF
--- a/ios/Sources/WidgetImageStorePlugin/WidgetImageStorePlugin.swift
+++ b/ios/Sources/WidgetImageStorePlugin/WidgetImageStorePlugin.swift
@@ -49,7 +49,7 @@ public class WidgetImageStorePlugin: CAPPlugin, CAPBridgedPlugin {
             UIGraphicsEndImageContext()
         }
 
-        guard let jpgData = image.jpegData(compressionQuality: 0.85) else {
+        guard let pngData = image.pngData() else {
             call.reject("Image conversion failed")
             return
         }
@@ -58,7 +58,7 @@ public class WidgetImageStorePlugin: CAPPlugin, CAPBridgedPlugin {
         let fileURL = dir?.appendingPathComponent(filename)
 
         do {
-            try jpgData.write(to: fileURL!)
+            try pngData.write(to: fileURL!)
             call.resolve(["path": fileURL!.path])
         } catch {
             call.reject("File write error: \(error.localizedDescription)")


### PR DESCRIPTION
Hey there 👋 

Fantastic plugin!

This change has been crafted due to a necessity for preserving the alpha channel of B64 image data when transferring into the shared iOS container. This is a quick fix in order to allow the transparency channel to work without any serious drawbacks (other than possibly a slightly higher file size due to not having the `compressionQuality` argument available.

Ideally, the plugin should check the file extension of the supplied path, or better still the mime-type and choose the correct renderer based on that - if you feel it's worth it i can see if i can find some spare time to make that change, although my native skills are pretty poor!